### PR TITLE
update for Rubocop 0.36.0

### DIFF
--- a/lib/scold/hound.yml
+++ b/lib/scold/hound.yml
@@ -118,8 +118,16 @@ Style/StringLiteralsInInterpolation:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/TrailingComma:
-  Description: Checks for trailing comma in parameter lists and literals.
+Style/TrailingCommaInArguments:
+  Description: Checks for trailing comma in parameter lists.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - no_comma
+Style/TrailingCommaInLiteral:
+  Description: Checks for trailing comma in literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false
   EnforcedStyleForMultiline: no_comma

--- a/lib/scold/version.rb
+++ b/lib/scold/version.rb
@@ -1,3 +1,3 @@
 module Scold
-  VERSION = "0.5.0"
+  VERSION = "0.6.0".freeze
 end

--- a/scold.gemspec
+++ b/scold.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version = Scold::VERSION
   s.platform = Gem::Platform::RUBY
   s.license  = "MIT"
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.2.4"
   s.authors = ["John Fearnside"]
   s.summary = "Hound-like Rubocop utility"
   s.description = "#{s.summary}."
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.extra_rdoc_files = %w(README.md)
   s.rubygems_version = "2.5.0"
-  s.add_runtime_dependency("rubocop", "~> 0.35")
-  s.add_development_dependency("bundler", "~> 1.10")
-  s.add_development_dependency("rspec", "~> 3.3")
+  s.add_runtime_dependency("rubocop", "~> 0.36")
+  s.add_development_dependency("bundler", "~> 1.11")
+  s.add_development_dependency("rspec", "~> 3.4")
 end


### PR DESCRIPTION
Rubocop 0.36.0 replaced the `Style/TrailingComma` cop with separate `Style/TrailingCommaInArguments` and `Style/TrailingCommaInLiteral` cops.
