### PR TITLE
Update scold.gemspec

### DIFF
--- a/scold.gemspec
+++ b/scold.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.extra_rdoc_files = %w(README.md)
   s.rubygems_version = "2.5.0"
-  s.add_runtime_dependency("rubocop", "~> 0.37.2")
-  s.add_development_dependency("bundler", "~> 1.11.2")
+  s.add_runtime_dependency("rubocop", "~> 0.37")
+  s.add_development_dependency("bundler", "~> 1.11")
   s.add_development_dependency("rspec", "~> 3.4")
 end


### PR DESCRIPTION
Update gemspec to allow rubocop and bundler to be updated to other minor versions instead of just patch-level changes.